### PR TITLE
Add composer support (Fixes #5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/nbproject/private/
+/vendor/
+composer.lock
+# Composer.lock should normally be included but is not recommended for libraries

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "spirit55555/php-minecraft",
+    "keywords": ["minecraft", "votifier", "chat"],
+    "description": "Useful PHP classes for Minecraft",
+    "type": "library",
+    "homepage": "https://github.com/Spirit55555/PHP-Minecraft/",
+    "support": {
+        "issues": "https://github.com/Spirit55555/PHP-Minecraft/issues",
+        "source": "https://github.com/Spirit55555/PHP-Minecraft"
+    },
+    "require": {
+        "php": ">=5.4"
+    },
+    "license": "GPLv3",
+    "autoload": {
+        "psr-4": {
+            "Spirit55555\\Minecraft\\": "src"
+        }
+    }
+}

--- a/src/MinecraftColors.php
+++ b/src/MinecraftColors.php
@@ -16,6 +16,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+namespace Spirit55555\Minecraft;
+
 class MinecraftColors {
 	const REGEX = '/(?:§|&amp;)([0-9a-fklmnor])/i';
 

--- a/src/MinecraftVotifier.php
+++ b/src/MinecraftVotifier.php
@@ -16,6 +16,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+namespace Spirit55555\Minecraft;
+
 class MinecraftVotifier {
 	const VOTE_FORMAT       = "VOTE\n%s\n%s\n%s\n%d\n";
 	const PUBLIC_KEY_FORMAT = "-----BEGIN PUBLIC KEY-----\n%s\n-----END PUBLIC KEY-----";
@@ -55,12 +57,12 @@ class MinecraftVotifier {
 			// Use Client Address BEHIND Proxy if it is a transparent proxy...
 			$address = isset($_SERVER["HTTP_X_FORWARDED_FOR"]) ? $_SERVER["HTTP_X_FORWARDED_FOR"] : $_SERVER['REMOTE_ADDR'];
 		}
-		
+
 		else {
 			// Script is run by CLI, use our own Name
 			$address = $_SERVER["HOST_NAME"];
 		}
-		
+
 		$vote = sprintf(self::VOTE_FORMAT, $this->service_name, $username, $address, time());
 
 		openssl_public_encrypt($vote, $data, $this->public_key);


### PR DESCRIPTION
After this PR, users of composer could just do:
```composer require spirit55555/php-minecraft```

and then use it with 

```PHP

use \Spirit55555\Minecraft\MinecraftColors;

class test
{
    public function functionName($param)
    {
        MinecraftColors::clean("test");
    }
}
```

Stuff you need to do.

- Submit the package url here: https://packagist.org/packages/submit
- Set up a packagist hook: https://github.com/Spirit55555/PHP-Minecraft/settings/hooks
 in order to notify packagist to deploy a new version when necessary
- Tag the first version. You only need to submit a version number